### PR TITLE
Update `print.StationBoard` to handle `ArrDepBoardWithDetails` requests

### DIFF
--- a/R/store.R
+++ b/R/store.R
@@ -36,6 +36,11 @@ store.StationBoard <- function(x, ..., file) {
   # Local bindings
   busServices <- ferryServices <- nrccMessages <- trainServices <- NULL
 
+  if (all(is.na(x$busServices)) &
+      all(is.na(x$ferryServices)) &
+      all(is.na(x$trainServices)))
+    return() # Don't create a workbook, if there are no services
+
   # Create workbook
   wb <- openxlsx::createWorkbook(title = "trainR")
   # Add worksheet "StationBoard"

--- a/man/GetArrBoardWithDetailsRequest.Rd
+++ b/man/GetArrBoardWithDetailsRequest.Rd
@@ -99,15 +99,6 @@ zero items, or may not be present at all.}
 Get all public arrivals for the supplied CRS code within a defined time
 window, including service details.
 }
-
-\seealso{
-Other OpenLDBSVWS requests: 
-\code{\link{GetArrDepBoardWithDetailsRequest}()},
-\code{\link{GetDepBoardWithDetailsRequest}()},
-\code{\link{GetServiceDetailsRequest}()}
-}
-\concept{OpenLDBSVWS requests}
-
 \examples{
 \dontrun{
 rdg_arr <- trainR::GetArrBoardWithDetailsRequest("RDG")
@@ -115,3 +106,10 @@ rdg_arr <- trainR::GetArrBoardWithDetailsRequest("RDG", filterCrs = "BRI")
 trainR::print(rdg_arr)
 }
 }
+\seealso{
+Other OpenLDBSVWS requests: 
+\code{\link{GetArrDepBoardWithDetailsRequest}()},
+\code{\link{GetDepBoardWithDetailsRequest}()},
+\code{\link{GetServiceDetailsRequest}()}
+}
+\concept{OpenLDBSVWS requests}

--- a/man/GetArrDepBoardWithDetailsRequest.Rd
+++ b/man/GetArrDepBoardWithDetailsRequest.Rd
@@ -100,15 +100,6 @@ zero items, or may not be present at all.}
 Get all public arrivals and departures for the supplied CRS code within a
 defined time window, including service details.
 }
-
-\seealso{
-Other OpenLDBSVWS requests: 
-\code{\link{GetArrBoardWithDetailsRequest}()},
-\code{\link{GetDepBoardWithDetailsRequest}()},
-\code{\link{GetServiceDetailsRequest}()}
-}
-\concept{OpenLDBSVWS requests}
-
 \examples{
 \dontrun{
 rdg<- trainR::GetArrDepBoardWithDetailsRequest("RDG")
@@ -116,3 +107,10 @@ rdg <- trainR::GetArrDepBoardWithDetailsRequest("RDG", filterCrs = "BRI")
 trainR::print(rdg)
 }
 }
+\seealso{
+Other OpenLDBSVWS requests: 
+\code{\link{GetArrBoardWithDetailsRequest}()},
+\code{\link{GetDepBoardWithDetailsRequest}()},
+\code{\link{GetServiceDetailsRequest}()}
+}
+\concept{OpenLDBSVWS requests}

--- a/man/GetDepBoardWithDetailsRequest.Rd
+++ b/man/GetDepBoardWithDetailsRequest.Rd
@@ -99,15 +99,6 @@ zero items, or may not be present at all.}
 Get all public departures for the supplied CRS code within a defined time
 window, including service details.
 }
-
-\seealso{
-Other OpenLDBSVWS requests: 
-\code{\link{GetArrBoardWithDetailsRequest}()},
-\code{\link{GetArrDepBoardWithDetailsRequest}()},
-\code{\link{GetServiceDetailsRequest}()}
-}
-\concept{OpenLDBSVWS requests}
-
 \examples{
 \dontrun{
 rdg_dep <- trainR::GetDepBoardWithDetailsRequest("RDG")
@@ -115,3 +106,10 @@ rdg_dep <- trainR::GetDepBoardWithDetailsRequest("RDG", filterCrs = "BRI")
 trainR::print(rdg_dep)
 }
 }
+\seealso{
+Other OpenLDBSVWS requests: 
+\code{\link{GetArrBoardWithDetailsRequest}()},
+\code{\link{GetArrDepBoardWithDetailsRequest}()},
+\code{\link{GetServiceDetailsRequest}()}
+}
+\concept{OpenLDBSVWS requests}

--- a/man/trainR-package.Rd
+++ b/man/trainR-package.Rd
@@ -6,8 +6,15 @@
 \alias{trainR-package}
 \title{trainR: An Interface to the National Rail Enquiries Systems}
 \description{
-The goal of trainR is to provide a simple interface to the National 
-    Rail Enquiries (NRE) systems.
+The goal of 'trainR' is to provide a simple interface to the 
+    National Rail Enquiries (NRE) systems. There are few data feeds 
+    available, the simplest of them is Darwin, which provides real-time 
+    arrival and departure predictions, platform numbers, delay estimates, 
+    schedule changes and cancellations. Other data feeds provide historical 
+    data, Historic Service Performance (HSP), and much more. 'trainR' 
+    simplifies the data retrieval, so that the users can focus on their 
+    analyses. For more details visit 
+    <https://www.nationalrail.co.uk/46391.aspx>.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Closes #4 

`ArrDepBoardWithDetails` requests now display two individual boards:

```{r}
> trainR::GetArrDepBoardWithDetailsRequest("RDG")
Reading (RDG) Station Board on 2021-01-28 22:45:31
Time   From                                    Plat  Expected
22:44  London Paddington                       12    On time
22:42  Manchester Piccadilly                   7B    On time
22:50  Salisbury                               11    On time
23:03  Oxford                                  15    On time
23:04  Worcester Foregate Street               12    On time
23:06  Basingstoke                             15    On time
23:13  London Paddington                       13    On time

Time   To                                      Plat  Expected
22:46  Didcot Parkway                          12    On time
22:48  Ealing Broadway                         10    On time
22:49  Southampton Central                     7B    On time
22:52  Ealing Broadway                         14    On time
23:06  London Paddington                       12    On time
23:12  Ascot                                   6     On time
```
