### PR TITLE
Add support for services with multiple locations

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -60,17 +60,19 @@ extract.ServiceDetails <- function(x, ...) {
 #' @rdname extract
 #' @keywords internal
 extract.ServiceLocation <- function(x, ...) {
-  x <- x[[1]]
   if (all(is.null(x)) |
       all(is.na(x)) |
       length(x) == 0 |
       is.null(x[[1]]))
     return(NA)
-  tibble::tibble(locationName = get_element(x, "locationName"),
-                 crs = get_element(x, "crs"),
-                 via = get_element(x, "via"),
-                 futureChangeTo = get_element(x, "futureChangeTo"),
-                 assocIsCancelled = get_element(x, "assocIsCancelled")) %>%
+  x %>%
+    purrr::map_df(
+      ~tibble::tibble(locationName = get_element(.x, "locationName"),
+                      crs = get_element(.x, "crs"),
+                      via = get_element(.x, "via"),
+                      futureChangeTo = get_element(.x, "futureChangeTo"),
+                      assocIsCancelled = get_element(.x, "assocIsCancelled"))
+    ) %>%
     list() %>%
     reclass("ServiceLocation")
 }

--- a/R/print-utils.R
+++ b/R/print-utils.R
@@ -1,0 +1,44 @@
+.glue_details <- function(expected, platform, station, time, via, show_colours) {
+  if (is.na(time)) time <- ""
+  if (is.na(station)) station <- ""
+  if (is.na(platform)) platform <- ""
+  if (is.na(via)) via <- ""
+  glue::glue("{stringr::str_pad(time, 7, 'right')}",
+             "{stringr::str_pad(station, 40, 'right')}",
+             "{stringr::str_pad(platform, 6, 'right')}",
+             "{colour_time(time, expected, show_colours)}\n",
+             "{via %>% .print_via}",
+             "{ifelse(!is.na(via) & via != '', '\n', '')}")
+}
+
+.print_service_details <- function(expected, platform, station, time, via, show_colours, ...) {
+  if (length(station) > 1 & length(via) > 1) { # Services with multiple locations
+    locations <- paste0(station, collapse = " and ")
+    if (length(unique(via)) == 1) {
+      via[1:(length(via) - 1)] <- NA
+      if (nchar(locations) <= 40) {
+        return(.glue_details(expected = expected,
+                             platform = platform,
+                             station = locations,
+                             time = time,
+                             via = via[length(via)],
+                             show_colours = show_colours))
+      }
+    }
+    aux <- .glue_details(expected, platform, station[1], time, via[1], show_colours)
+    paste0(aux,
+           purrr::map_chr(seq_along(station)[-1],
+                          function(i) {
+                            .glue_details(NA, NA, paste("and", station[i]), NA, via[i], show_colours)
+                          }),
+           collapse = "\n")
+  } else { # Services with single location
+    .glue_details(expected, platform, station, time, via, show_colours)
+  }
+}
+
+.print_via <- function(.data) {
+  ifelse(!is.na(.data) & .data != "",
+         stringr::str_pad(stringr::str_pad(.data, 40, 'right'), 47, 'left'),
+         '')
+}

--- a/R/print.R
+++ b/R/print.R
@@ -170,11 +170,11 @@ print_board <- function(x,
                   via =
                     get_element(x, station, TRUE) %>%
                     purrr::transpose() %>%
-                    get_element("via"),
+                    get_element("via", TRUE),
                   station =
                     get_element(x, station, TRUE) %>%
                     purrr::transpose() %>%
-                    get_element("locationName"))
+                    get_element("locationName", TRUE))
 
   if (string) {
     return(x %>%
@@ -206,18 +206,14 @@ print_board <- function(x,
                 })
   } else {
     x %>%
-      glue::glue_data("{stringr::str_pad(time, 7, 'right')}",
-                      "{stringr::str_pad(station, 40, 'right')}",
-                      "{stringr::str_pad(platform, 6, 'right')}",
-                      "{colour_time(time, expected, show_colours)}\n",
-                      "{ifelse(!is.na(via),
-                               stringr::str_pad(stringr::str_pad(via,
-                                                                 40,
-                                                                 'right'),
-                                                47,
-                                                'left'),
-                               '')}",
-                      "{ifelse(!is.na(via), '\n', '')}") %>%
+      purrr::pmap_chr(.print_service_details,
+                      show_colours = show_colours) %>%
+      # glue::glue_data("{stringr::str_pad(time, 7, 'right')}",
+      #                 "{stringr::str_pad(station, 40, 'right')}",
+      #                 "{stringr::str_pad(platform, 6, 'right')}",
+      #                 "{colour_time(time, expected, show_colours)}\n",
+      #                 "{via %>% .print_via}",
+      #                 "{ifelse(!is.na(via), '\n', '')}") %>%
       purrr::walk(cat)
   }
 }

--- a/R/utils-colour.R
+++ b/R/utils-colour.R
@@ -10,6 +10,8 @@
 #' @return
 #' @keywords internal
 colour_time <- function(time, expected, show_colours = TRUE) {
+  if (is.na(time) | time == "")
+    return("")
   if (!show_colours)
     return(expected)
   purrr::map2_chr(time, expected,

--- a/README.Rmd
+++ b/README.Rmd
@@ -173,6 +173,27 @@ trainR::GetDepBoardWithDetailsRequest("CRE")
 #   knitr::kable()
 ```
 
+## Get services without details (calling points)
+These requests are useful if the calling points are not relevant for your analyses, visualisations, etc.
+
+### Arrivals board at Reading Station (RDG)
+
+Generated on `r lubridate::now()`.
+
+```{r arrivals-wo-details}
+rdg_arr <- trainR::GetArrBoardRequest("RDG")
+print(rdg_arr)
+```
+
+### Departures board at Reading Station (RDG)
+
+Generated on `r lubridate::now()`.
+
+```{r departures-wo-details}
+rdg_dep <- trainR::GetDepBoardRequest("RDG")
+print(rdg_dep)
+```
+
 ## Acknowledgements
 
 Access to the data feeds it is only possible thanks to the National Rail Enquiries. This package is just a tool to facilitate access to the data. For more information about the available data feeds, visit https://www.nationalrail.co.uk.

--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ library(trainR)
 
 ### Arrivals board at Reading Station (RDG)
 
-Generated on 2021-02-05 12:10:10.
+Generated on 2021-02-06 15:42:40.
 
 ``` r
 rdg_arr <- trainR::GetArrBoardWithDetailsRequest("RDG")
 print(rdg_arr)
-#> Reading (RDG) Station Board on 2021-02-05 12:10:10
+#> Reading (RDG) Station Board on 2021-02-06 15:42:41
 #> Time   From                                    Plat  Expected
-#> 11:59  Didcot Parkway                          15    11:56
-#> 12:11  London Paddington                       9B    On time
-#> 12:13  London Paddington                       14    12:08
-#> 12:14  London Paddington                       12    On time
-#> 12:15  London Waterloo                         4     On time
-#> 12:16  London Paddington                       8B    12:18
-#> 12:17  Basingstoke                             2     On time
-#> 12:22  Bedwyn                                  11A   On time
-#> 12:29  Cheltenham Spa                          11A   On time
-#> 12:33  Redhill                                 5     On time
+#> 15:40  Bristol Temple Meads                    10    15:37
+#> 15:43  London Paddington                       14    On time
+#> 15:44  London Paddington                       12    15:49
+#> 15:47  Swansea                                 10    On time
+#> 15:53  London Paddington                       9     15:56
+#> 15:54  Hereford                                10A   15:57
+#> 15:57  Basingstoke                             2     On time
+#> 16:11  London Paddington                       9     On time
+#> 16:11  London Waterloo                         4     On time
+#> 16:13  London Paddington                       14    On time
 ```
 
 <!-- Inspect the `rdg_arr` object: -->
@@ -98,24 +98,23 @@ print(rdg_arr)
 
 ### Departures board at Reading Station (RDG)
 
-Generated on 2021-02-05 12:10:10.
+Generated on 2021-02-06 15:42:42.
 
 ``` r
 rdg_dep <- trainR::GetDepBoardWithDetailsRequest("RDG")
 print(rdg_dep)
-#> Reading (RDG) Station Board on 2021-02-05 12:10:11
+#> Reading (RDG) Station Board on 2021-02-06 15:42:43
 #> Time   To                                      Plat  Expected
-#> 12:12  Ealing Broadway                         15    On time
-#> 12:12  London Waterloo                         6     On time
-#> 12:12  Newbury                                 1     On time
-#> 12:13  Manchester Piccadilly                   8B    On time
-#>        via Coventry & Stoke-on-Trent           
-#> 12:13  Swansea                                 9B    On time
-#> 12:18  Hereford                                8B    12:19
-#> 12:20  Redhill                                 5     On time
-#> 12:22  Ealing Broadway                         14    On time
-#> 12:23  Didcot Parkway                          12    On time
-#> 12:24  London Paddington                       11A   On time
+#> 15:41  London Paddington                       10    On time
+#> 15:42  London Waterloo                         4     On time
+#> 15:50  London Paddington                       10    On time
+#> 15:52  Basingstoke                             2     On time
+#> 15:52  Ealing Broadway                         14    On time
+#> 15:53  Didcot Parkway                          12    On time
+#> 15:55  Bristol Temple Meads                    9     15:57
+#> 15:56  London Paddington                       10A   15:58
+#> 16:10  Newbury                                 1     On time
+#> 16:12  London Waterloo                         6     On time
 ```
 
 ### Add some colour (Terminal output only)
@@ -145,6 +144,121 @@ trainR::GetDepBoardWithDetailsRequest("CRE")
 <img alt="Crewe station - Departures Board" src="man/figures/README-CRE-DEP-terminal-output-2.png" style="max-width:500px;width:100%">
 
 <!-- #### Previous calling points -->
+
+## Get services without details (calling points)
+
+These requests are useful if the calling points are not relevant for
+your analyses, visualisations, etc.
+
+### Arrivals board at Reading Station (RDG)
+
+Generated on 2021-02-06 15:42:43.
+
+``` r
+rdg_arr <- trainR::GetArrBoardRequest("RDG")
+print(rdg_arr)
+#> Reading (RDG) Station Board on 2021-02-06 15:42:44
+#> Time   From                                    Plat  Expected
+#> 15:40  Bristol Temple Meads                    10    15:37
+#> 15:41  London Waterloo                         6     On time
+#> 15:43  London Paddington                       14    On time
+#> 15:44  London Paddington                       12    15:49
+#> 15:47  Swansea                                 10    On time
+#> 15:53  London Paddington                       9     15:56
+#> 15:54  Hereford                                10A   15:57
+#> 15:57  Basingstoke                             2     On time
+#> 16:01  Didcot Parkway                          15    On time
+#> 16:11  London Paddington                       9     On time
+#> 16:11  London Waterloo                         4     On time
+#> 16:13  London Paddington                       14    On time
+#> 16:16  London Paddington                       9B    On time
+#> 16:17  Plymouth                                11    On time
+#> 16:26  London Paddington                       7     On time
+#> 16:27  Bedwyn                                  11A   On time
+#> 16:31  London Paddington                       7B    On time
+#> 16:33  Redhill                                 5     On time
+#> 16:39  Manchester Piccadilly                   7B    On time
+#> 16:40  Bristol Temple Meads                    10    On time
+#> 16:41  London Waterloo                         6     On time
+#> 16:41  Newbury                                 1     On time
+#> 16:43  London Paddington                       14    On time
+#> 16:44  London Paddington                       12    On time
+#> 16:46  Swansea                                 10    On time
+#> 16:53  London Paddington                       9     On time
+#> 16:54  Worcester Foregate Street               10A   On time
+#> 16:56  Basingstoke                             2     On time
+#> 16:56  London Paddington                       8B    On time
+#> 17:01  Didcot Parkway                          15    On time
+#> 17:02  Penzance                                11A   On time
+#> 17:10  Bournemouth                             13B   On time
+#> 17:11  London Paddington                       9     On time
+#> 17:11  London Waterloo                         4     On time
+#> 17:13  London Paddington                       14    On time
+#> 17:16  London Paddington                       9B    On time
+#> 17:21  Bedwyn                                  11A   On time
+#> 17:32  London Paddington                       7B    On time
+#> 17:33  Cheltenham Spa                          11A   On time
+#> 17:33  Redhill                                 5     On time
+#> 17:38  Newbury                                 1     On time
+#> 17:39  Manchester Piccadilly                   7     On time
+```
+
+### Departures board at Reading Station (RDG)
+
+Generated on 2021-02-06 15:42:44.
+
+``` r
+rdg_dep <- trainR::GetDepBoardRequest("RDG")
+print(rdg_dep)
+#> Reading (RDG) Station Board on 2021-02-06 15:42:45
+#> Time   To                                      Plat  Expected
+#> 15:41  London Paddington                       10    On time
+#> 15:42  London Waterloo                         4     On time
+#> 15:50  London Paddington                       10    On time
+#> 15:52  Basingstoke                             2     On time
+#> 15:52  Ealing Broadway                         14    On time
+#> 15:53  Didcot Parkway                          12    On time
+#> 15:55  Bristol Temple Meads                    9     15:57
+#> 15:56  London Paddington                       10A   15:58
+#> 16:10  Newbury                                 1     On time
+#> 16:12  London Waterloo                         6     On time
+#> 16:13  Swansea                                 9     On time
+#> 16:15  Ealing Broadway                         15    On time
+#> 16:15  Manchester Piccadilly                   13B   On time
+#>        via Coventry & Stoke-on-Trent           
+#> 16:19  Great Malvern                           9B    On time
+#> 16:19  London Paddington                       11    On time
+#> 16:20  Redhill                                 5     On time
+#> 16:22  Ealing Broadway                         14    On time
+#> 16:28  Plymouth                                7     On time
+#> 16:30  London Paddington                       11A   On time
+#> 16:34  Bedwyn                                  7B    On time
+#> 16:41  London Paddington                       10    On time
+#> 16:42  London Waterloo                         4     On time
+#> 16:48  London Paddington                       10    On time
+#> 16:49  Bournemouth                             7B    On time
+#> 16:52  Basingstoke                             2     On time
+#> 16:52  Ealing Broadway                         14    On time
+#> 16:53  Didcot Parkway                          12    On time
+#> 16:55  Bristol Temple Meads                    9     On time
+#> 16:56  London Paddington                       10A   On time
+#> 16:58  Cheltenham Spa                          8B    On time
+#> 17:05  London Paddington                       11A   On time
+#> 17:10  Newbury                                 1     On time
+#> 17:12  London Waterloo                         6     On time
+#> 17:13  Swansea                                 9     On time
+#> 17:15  Ealing Broadway                         15    On time
+#> 17:15  Manchester Piccadilly                   13B   On time
+#>        via Coventry & Stoke-on-Trent           
+#> 17:19  Hereford                                9B    On time
+#> 17:20  Redhill                                 5     On time
+#> 17:22  Ealing Broadway                         14    On time
+#> 17:23  London Paddington                       11A   On time
+#> 17:29  Penzance                                7     On time
+#> 17:34  Bedwyn                                  7B    On time
+#> 17:35  London Paddington                       11A   On time
+#> 17:41  London Paddington                       10    On time
+```
 
 ## Acknowledgements
 


### PR DESCRIPTION
Some services have multiple origins and/or destinations, previously only the first location was captured. This new patch includes support for multiple services. These services are display, as shown below:

```{r}
> trainR::GetDepBoardRequest("GTW")
Gatwick Airport (GTW) Station Board on 2021-02-14 21:09:54
Time   To                                      Plat  Expected
21:06  Brighton                                7     21:09
21:09  London Bridge                           1     On time
21:11  Brighton                                7     21:15
21:11  Three Bridges                           3     On time
21:15  Chichester and Bognor Regis             3     On time
       via Horsham                             
```

The `21:15` service has two destinations `Chichester` and `Bognor Regis` via `Horsham`. 